### PR TITLE
Add AccessToken.has_scope()

### DIFF
--- a/provider/oauth2/models.py
+++ b/provider/oauth2/models.py
@@ -109,7 +109,7 @@ class AccessToken(models.Model):
         Return `True` if the token satisfies the required scope.
         `required` may be provided as either the integer or string representation.
         """
-        if not isinstance(required, int):
+        if isinstance(required, basestring):
             required = scope.SCOPE_NAME_DICT[required]
         return scope.check(required, self.scope)
 

--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -115,4 +115,13 @@ class AuthBackendTest(TestCase, Mixin):
         self.assertIsNotNone(AccessTokenBackend().authenticate(access_token = token.token,
                                                                client = self.get_client()))
 
-    
+    def test_has_scope(self):
+        token = AccessToken.objects.create(
+            user=self.get_user(),
+            client=self.get_client(),
+            scope=constants.READ
+        )
+        self.assertTrue(token.has_scope('read'))
+        self.assertFalse(token.has_scope('write'))
+        self.assertTrue(token.has_scope(constants.READ))
+        self.assertFalse(token.has_scope(constants.WRITE))


### PR DESCRIPTION
Adding this method helps decouple the API concerns from the implementation concerns.

Example:

A reusable REST framework TokenHasRequiredScope() class can be implemented which supports django-oauth2-provider, but is not coupled to it's implementation.
Including the string-or-integer behavior is also required, since the scope constants are particular to django-oauth2-provider. 
