### PR TITLE
Add timezone-awareness

### DIFF
--- a/provider/oauth2/backends.py
+++ b/provider/oauth2/backends.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from django.utils import timezone
 from .forms import ClientAuthForm
 from .models import AccessToken
 
@@ -69,6 +69,6 @@ class AccessTokenBackend(object):
     def authenticate(self, access_token=None, client=None):
         try:
             return AccessToken.objects.get(token=access_token,
-                expires__gt=datetime.now(), client=client)
+                expires__gt=timezone.now(), client=client)
         except AccessToken.DoesNotExist:
             return None

--- a/provider/oauth2/forms.py
+++ b/provider/oauth2/forms.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 from django import forms
+from django.utils import timezone
 from django.contrib.auth import authenticate
 from django.utils.encoding import smart_unicode
 from django.utils.translation import ugettext as _
@@ -242,7 +242,7 @@ class AuthorizationCodeGrantForm(ScopeMixin, OAuthForm):
 
         try:
             self.cleaned_data['grant'] = Grant.objects.get(
-                code=code, client=self.client, expires__gt=datetime.now())
+                code=code, client=self.client, expires__gt=timezone.now())
         except Grant.DoesNotExist:
             raise OAuthValidationError({'error': 'invalid_grant'})
 

--- a/provider/oauth2/managers.py
+++ b/provider/oauth2/managers.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from django.utils import timezone
 from django.db import models
 
 
 class AccessTokenManager(models.Manager):
     def get_token(self, token):
-        return self.get(token=token, expires__gt=datetime.now())
+        return self.get(token=token, expires__gt=timezone.now())

--- a/provider/oauth2/models.py
+++ b/provider/oauth2/models.py
@@ -4,9 +4,9 @@ implement these models with fields and and methods to be compatible with the
 views in :attr:`provider.views`.
 """
 
-from datetime import datetime
 from django.db import models
 from django.conf import settings
+from django.utils import timezone
 from .. import constants
 from ..constants import CLIENT_TYPES
 from ..utils import short_token, long_token, get_token_expiry
@@ -108,7 +108,7 @@ class AccessToken(models.Model):
         """
         Return the number of seconds until this token expires.
         """
-        return (self.expires - datetime.now()).seconds
+        return (self.expires - timezone.now()).seconds
 
 
 class RefreshToken(models.Model):

--- a/provider/oauth2/views.py
+++ b/provider/oauth2/views.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
+from django.utils import timezone
 from django.core.urlresolvers import reverse
 from ..views import Capture, Authorize, Redirect
 from ..views import AccessToken as AccessTokenView, OAuthError
@@ -104,7 +105,7 @@ class AccessTokenView(AccessTokenView):
         )
 
     def invalidate_grant(self, grant):
-        grant.expires = datetime.now() - timedelta(days=1)
+        grant.expires = timezone.now() - timedelta(days=1)
         grant.save()
 
     def invalidate_refresh_token(self, rt):
@@ -112,5 +113,5 @@ class AccessTokenView(AccessTokenView):
         rt.save()
 
     def invalidate_access_token(self, at):
-        at.expires = datetime.now() - timedelta(days=1)
+        at.expires = timezone.now() - timedelta(days=1)
         at.save()

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import shortuuid
-from datetime import datetime
 from django.conf import settings
+from django.utils import timezone
 from .constants import EXPIRE_DELTA, EXPIRE_CODE_DELTA
 
 
@@ -29,7 +29,7 @@ def get_token_expiry():
     Can be customized by setting :attr:`settings.OAUTH_EXPIRE_DELTA` to a
     :attr:`datetime.timedelta` object.
     """
-    return datetime.now() + EXPIRE_DELTA
+    return timezone.now() + EXPIRE_DELTA
 
 
 def get_code_expiry():
@@ -39,4 +39,4 @@ def get_code_expiry():
     Can be customized by setting :attr:`settings.OAUTH_EXPIRE_CODE_DELTA` to a
     :attr:`datetime.timedelta` object.
     """
-    return datetime.now() + EXPIRE_CODE_DELTA
+    return timezone.now() + EXPIRE_CODE_DELTA


### PR DESCRIPTION
This adds timezone support and addresses #4. Use `django.utils.timezone.now` instead of `datetime.datetime.now` so that "now" references are timezone-aware based on the value of `USE_TZ` setting.
