### PR TITLE
Improve cross python compatibility issues with little imports

### DIFF
--- a/provider/oauth2/__init__.py
+++ b/provider/oauth2/__init__.py
@@ -1,0 +1,6 @@
+import backends
+import forms
+import managers
+import models
+import urls
+import views


### PR DESCRIPTION
Very little thing, but it helps to not breaks things in older version of `Django (<=1.3)`
