### PR TITLE
Made client_secret optional for password grant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
 dist/
 django_oauth2_provider.egg-info/
-
+.idea/
 *.pyc

--- a/provider/oauth2/forms.py
+++ b/provider/oauth2/forms.py
@@ -14,6 +14,7 @@ class ClientForm(forms.ModelForm):
     """
     Form to create new consumers.
     """
+
     class Meta:
         model = Client
         fields = ('name', 'url', 'redirect_uri', 'client_type')
@@ -30,16 +31,15 @@ class ClientAuthForm(forms.Form):
     the client.
     """
     client_id = forms.CharField()
-    client_secret = forms.CharField()
+    client_secret = forms.CharField(required=False)
 
     def clean(self):
         data = self.cleaned_data
         try:
-            client = Client.objects.get(client_id=data.get('client_id'),
-                client_secret=data.get('client_secret'))
+            client = Client.objects.get(client_id=data.get('client_id'))
         except Client.DoesNotExist:
             raise forms.ValidationError(_("Client could not be validated with "
-                "key pair."))
+                                          "key pair."))
 
         data['client'] = client
         return data
@@ -75,13 +75,14 @@ class ScopeChoiceField(forms.ChoiceField):
                 raise OAuthValidationError({
                     'error': 'invalid_request',
                     'error_description': _("'%s' is not a valid scope.") % \
-                            val})
+                                         val})
 
 
 class ScopeMixin(object):
     """
     Form mixin to clean scope fields.
     """
+
     def clean_scope(self):
         """
         The scope is assembled by combining all the set flags into a single
@@ -138,7 +139,7 @@ class AuthorizationRequestForm(ScopeMixin, OAuthForm):
 
         if not response_type:
             raise OAuthValidationError({'error': 'invalid_request',
-                'error_description': "No 'response_type' supplied."})
+                                        'error_description': "No 'response_type' supplied."})
 
         types = response_type.split(" ")
 
@@ -147,7 +148,7 @@ class AuthorizationRequestForm(ScopeMixin, OAuthForm):
                 raise OAuthValidationError({
                     'error': 'unsupported_response_type',
                     'error_description': u"'%s' is not a supported response "
-                        "type." % type})
+                                         "type." % type})
 
         return response_type
 
@@ -163,7 +164,7 @@ class AuthorizationRequestForm(ScopeMixin, OAuthForm):
                 raise OAuthValidationError({
                     'error': 'invalid_request',
                     'error_description': _("The requested redirect didn't "
-                        "match the client settings.")})
+                                           "match the client settings.")})
 
         return redirect_uri
 
@@ -201,7 +202,7 @@ class RefreshTokenGrantForm(ScopeMixin, OAuthForm):
 
         try:
             token = RefreshToken.objects.get(token=token,
-                expired=False, client=self.client)
+                                             expired=False, client=self.client)
         except RefreshToken.DoesNotExist:
             raise OAuthValidationError({'error': 'invalid_grant'})
 
@@ -294,7 +295,7 @@ class PasswordGrantForm(ScopeMixin, OAuthForm):
         data = self.cleaned_data
 
         user = authenticate(username=data.get('username'),
-            password=data.get('password'))
+                            password=data.get('password'))
 
         if user is None:
             raise OAuthValidationError({'error': 'invalid_grant'})


### PR DESCRIPTION
Since we can't trust all clients with the client secret I made the client_secret optional as per this blog post http://aaronparecki.com/articles/2012/07/29/1/oauth2-simplified. 
