### PR TITLE
Cross-domain access to /oauth2/access-token

### DIFF
--- a/provider/oauth2/urls.py
+++ b/provider/oauth2/urls.py
@@ -36,6 +36,7 @@ that are meant for client (as defined in :draft:`1`) interaction.
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
 from ..compat.urls import *
+from ..utils import cross_domain_ajax
 from .views import Authorize, Redirect, Capture, AccessTokenView
 
 
@@ -50,6 +51,6 @@ urlpatterns = patterns('',
         login_required(Redirect.as_view()),
         name='redirect'),
     url('^access_token/?$',
-        csrf_exempt(AccessTokenView.as_view()),
+        cross_domain_ajax(csrf_exempt(AccessTokenView.as_view())),
         name='access_token'),
 )

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import shortuuid
 from datetime import datetime
 from django.conf import settings
+from django.http import HttpResponse
 from .constants import EXPIRE_DELTA, EXPIRE_CODE_DELTA
 
 
@@ -40,3 +41,22 @@ def get_code_expiry():
     :attr:`datetime.timedelta` object.
     """
     return datetime.now() + EXPIRE_CODE_DELTA
+
+
+
+def cross_domain_ajax(func):
+    """ Sets Access Control request headers."""
+    HEADERS = {'Access-Control-Allow-Origin': '*', 
+               'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+               'Access-Control-Max-Age': 1000,
+               'Access-Control-Allow-Headers': 'X-Requested-With'}
+    def wrap(request, *args, **kwargs):
+        # Firefox sends 'OPTIONS' request for cross-domain javascript call.
+        if request.method != "OPTIONS": 
+            response = func(request, *args, **kwargs)
+        else:
+            response = HttpResponse()
+        for k, v in HEADERS.iteritems():
+            response[k] = v
+        return response
+    return wrap


### PR DESCRIPTION
/oauth2/access-token properly features a CSRF decorator, but is missing the required CORS headers in order to post to the URL cross-domain from Javascript.
