### PR TITLE
"token_type" is required on access token response

### DIFF
--- a/provider/oauth2/views.py
+++ b/provider/oauth2/views.py
@@ -1,14 +1,16 @@
+import json
 from datetime import timedelta
+from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 from ..views import Capture, Authorize, Redirect
 from ..views import AccessToken as AccessTokenView, OAuthError
 from ..utils import now
+from .. import constants, scope
 from .forms import AuthorizationRequestForm, AuthorizationForm
 from .forms import PasswordGrantForm, RefreshTokenGrantForm
 from .forms import AuthorizationCodeGrantForm
 from .models import Client, RefreshToken, AccessToken
 from .backends import BasicClientBackend, RequestParamsClientBackend
-
 
 class Capture(Capture):
     """
@@ -89,6 +91,21 @@ class AccessTokenView(AccessTokenView):
         if not form.is_valid():
             raise OAuthError(form.errors)
         return form.cleaned_data
+
+    def access_token_response(self, access_token):
+        """
+        Returns a successful response after creating the access token
+        as defined in :final:`4.2.2`.
+        """
+        return HttpResponse(
+            json.dumps({
+                'access_token': access_token.token,
+                'expires_in': access_token.get_expire_delta(),
+                'refresh_token': access_token.refresh_token.token,
+                'scope': ' '.join(scope.names(access_token.scope)),
+                'token_type': 'Bearer',
+            }), mimetype='application/json'
+        )
 
     def get_access_token(self, request, user, scope, client):
         try:


### PR DESCRIPTION
As defined on final standard "token_type" is required on Access Token
Response. Libraries like AFNetwokring expect token_type to be defined as
Bearer if access_token is passed as plain.
http://tools.ietf.org/html/rfc6749#section-4.2.2

As this lib uses bearer token type it can be hardcoded.
