### PR TITLE
trigger a signal when a token is fetched

### DIFF
--- a/provider/signals.py
+++ b/provider/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+access_token_fetched = django.dispatch.Signal(providing_args=['request', 'created', 'instance'])


### PR DESCRIPTION
Hi,

In my project, I needed the equivalent of user_logged_in (from django.contrib.auth) so I can get the IP address (from request) of the user that's logging in. This is why I created this new signal, which is somewhat an equivalent for oauth2 (fetching a token).

Cheers,

Guillaume
