### PR TITLE
Implements the 'Implicit Grant'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _build
 dist
 build
 venv
+/.project
+/.pydevproject

--- a/provider/views.py
+++ b/provider/views.py
@@ -478,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token):
+    def access_token_response(self, access_token, data=None):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.

--- a/provider/views.py
+++ b/provider/views.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import TemplateView
 from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
+from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
 
 
@@ -261,11 +262,22 @@ class Authorize(OAuthView, Mixin):
         authorization_form = self.get_authorization_form(request, client,
             post_data, data)
 
-        if not authorization_form.is_bound or not authorization_form.is_valid():
-            return self.render_to_response({
-                'client': client,
-                'form': authorization_form,
-                'oauth_data': data, })
+        if data.get('response_type', None):
+            if data.get('response_type') == 'code':                
+                if not authorization_form.is_bound \
+                    or not authorization_form.is_valid():
+                    return self.render_to_response({
+                                                    'client': client,
+                                                    'form': authorization_form,
+                                                    'oauth_data': data, })
+            #implements the 'implicit grant'
+            elif data.get('response_type') == 'token':
+                #uses request.user as the urls.py already required login_required
+                atm = AccessTokenModel.objects.create(user=request.user,
+                                                client=client,
+                                                scope=data.get('scope'))
+                at = AccessToken()
+                return at.access_token_response(atm, data)
 
         code = self.save_authorization(request, client,
             authorization_form, data)
@@ -466,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token):
+    def access_token_response(self, access_token, data=None):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.
@@ -486,6 +498,13 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
+
+        if data.get('response_type') == 'token':
+            if len(data.get('state', '')) > 0:
+                response_data['state'] = data.get('state')
+            path = "%s?%s" % (data.get('redirect_uri'), 
+                              urlencode(response_data))                       
+            return HttpResponseRedirect(path)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'

--- a/provider/views.py
+++ b/provider/views.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 from django.views.generic.base import TemplateView
 from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
-from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
 
 
@@ -262,22 +261,11 @@ class Authorize(OAuthView, Mixin):
         authorization_form = self.get_authorization_form(request, client,
             post_data, data)
 
-        if data.get('response_type', None):
-            if data.get('response_type') == 'code':                
-                if not authorization_form.is_bound \
-                    or not authorization_form.is_valid():
-                    return self.render_to_response({
-                                                    'client': client,
-                                                    'form': authorization_form,
-                                                    'oauth_data': data, })
-            #implements the 'implicit grant'
-            elif data.get('response_type') == 'token':
-                #uses request.user as the urls.py already required login_required
-                atm = AccessTokenModel.objects.create(user=request.user,
-                                                client=client,
-                                                scope=data.get('scope'))
-                at = AccessToken()
-                return at.access_token_response(atm, data)
+        if not authorization_form.is_bound or not authorization_form.is_valid():
+            return self.render_to_response({
+                'client': client,
+                'form': authorization_form,
+                'oauth_data': data, })
 
         code = self.save_authorization(request, client,
             authorization_form, data)
@@ -478,7 +466,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token, data=None):
+    def access_token_response(self, access_token):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.
@@ -498,13 +486,6 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
-
-        if data.get('response_type') == 'token':
-            if len(data.get('state', '')) > 0:
-                response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
-                              urlencode(response_data))                       
-            return HttpResponseRedirect(path)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'

--- a/provider/views.py
+++ b/provider/views.py
@@ -277,7 +277,7 @@ class Authorize(OAuthView, Mixin):
                                                 client=client,
                                                 scope=data.get('scope'))
                 at = AccessToken()
-                return at.access_token_response(atm, data)
+                return at.access_token_response(atm)
 
         code = self.save_authorization(request, client,
             authorization_form, data)
@@ -478,7 +478,7 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token, data=None):
+    def access_token_response(self, access_token):
         """
         Returns a successful response after creating the access token
         as defined in :rfc:`5.1`.

--- a/provider/views.py
+++ b/provider/views.py
@@ -277,7 +277,7 @@ class Authorize(OAuthView, Mixin):
                                                 client=client,
                                                 scope=data.get('scope'))
                 at = AccessToken()
-                return at.access_token_response(atm)
+                return at.access_token_response(atm, data)
 
         code = self.save_authorization(request, client,
             authorization_form, data)

--- a/provider/views.py
+++ b/provider/views.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauth2.models import Client
 from oauth2.models import AccessToken as AccessTokenModel
 from . import constants, scope
+from django.utils.http import urlencode
 
 
 class OAuthError(Exception):

--- a/provider/views.py
+++ b/provider/views.py
@@ -499,10 +499,13 @@ class AccessToken(OAuthView, Mixin):
         except ObjectDoesNotExist:
             pass
 
-        if data.get('response_type') == 'token':
+        if data is not None and data.get('response_type') == 'token':
+            basepath = data.get("redirect_uri")
+            if not basepath:
+                basepath = access_token.client.redirect_uri
             if len(data.get('state', '')) > 0:
                 response_data['state'] = data.get('state')
-            path = "%s?%s" % (data.get('redirect_uri'), 
+            path = "%s#%s" % (basepath, 
                               urlencode(response_data))                       
             return HttpResponseRedirect(path)
 


### PR DESCRIPTION
A typical call looks like

/oauth2/authorize/?response_type=token&client_id=an_existing_client_id=token&redirect_uri=the_client_redirect_uri
