### PR TITLE
Make migrations compatible with user model without `id` field

### DIFF
--- a/provider/compat/__init__.py
+++ b/provider/compat/__init__.py
@@ -1,10 +1,11 @@
 from unittest import skipIf
 
 from django.conf import settings
+from django.contrib.contenttypes.generic import get_model
 
 
 user_model_label = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-
+user_model_class = lambda: get_model(*user_model_label.split('.'))
 
 try:
     from django.contrib.auth.tests.utils import skipIfCustomUser

--- a/provider/compat/__init__.py
+++ b/provider/compat/__init__.py
@@ -1,3 +1,5 @@
+from unittest import skipIf
+
 from django.conf import settings
 
 
@@ -8,4 +10,4 @@ try:
     from django.contrib.auth.tests.utils import skipIfCustomUser
 except ImportError:
     def skipIfCustomUser(wrapped):
-        return wrapped
+        return skipIf(settings.AUTH_USER_MODEL != 'auth.User', 'Custom user model in use')(wrapped)

--- a/provider/oauth2/migrations/0001_initial.py
+++ b/provider/oauth2/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from provider.compat import user_model_label
+from provider.compat import user_model_label, user_model_class
 
 
 class Migration(SchemaMigration):
@@ -89,19 +89,7 @@ class Migration(SchemaMigration):
         },
         user_model_label: {
             'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            user_model_class()._meta.pk.column: ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/provider/oauth2/migrations/0002_auto__chg_field_client_user.py
+++ b/provider/oauth2/migrations/0002_auto__chg_field_client_user.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from provider.compat import user_model_label
+from provider.compat import user_model_label, user_model_class
 
 
 class Migration(SchemaMigration):
@@ -37,19 +37,7 @@ class Migration(SchemaMigration):
         },
         user_model_label: {
             'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            user_model_class()._meta.pk.column: ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/provider/oauth2/migrations/0003_auto__add_field_client_name.py
+++ b/provider/oauth2/migrations/0003_auto__add_field_client_name.py
@@ -4,7 +4,7 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-from provider.compat import user_model_label
+from provider.compat import user_model_label, user_model_class
 
 
 class Migration(SchemaMigration):
@@ -37,19 +37,7 @@ class Migration(SchemaMigration):
         },
         user_model_label: {
             'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            user_model_class()._meta.pk.column: ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},


### PR DESCRIPTION
If you create a model deriving from auth.User its primary key field is `user_ptr_id` instead of `id`.

PS: In older versions of Django (where you could still derive from `auth.User` though) `skipIfCustomUser` is not present and this obviously breaks the tests. So I decided to simply implement it in case of `ImportError`. It's one line after all, not a rocket science.
