### PR TITLE
Fix for issue #70

### DIFF
--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -296,6 +296,23 @@ class AccessTokenTest(BaseOAuth2TestCase):
 
         constants.SINGLE_ACCESS_TOKEN = False
 
+    def test_fetching_single_access_token_after_refresh(self):
+        constants.SINGLE_ACCESS_TOKEN = True
+
+        token = self._login_authorize_get_token()
+
+        self.client.post(self.access_token_url(), {
+            'grant_type': 'refresh_token',
+            'refresh_token': token['refresh_token'],
+            'client_id': self.get_client().client_id,
+            'client_secret': self.get_client().client_secret,
+        })
+
+        new_token = self._login_authorize_get_token()
+        self.assertNotEqual(token['access_token'], new_token['access_token'])
+
+        constants.SINGLE_ACCESS_TOKEN = False
+
     def test_fetching_access_token_multiple_times(self):
         self._login_authorize_get_token()
         code = self.get_grant().code

--- a/provider/oauth2/views.py
+++ b/provider/oauth2/views.py
@@ -95,7 +95,8 @@ class AccessTokenView(AccessTokenView):
     def get_access_token(self, request, user, scope, client):
         try:
             # Attempt to fetch an existing access token.
-            at = AccessToken.objects.get(user=user, client=client, scope=scope)
+            at = AccessToken.objects.get(user=user, client=client,
+                                         scope=scope, expires__gt=now())
         except AccessToken.DoesNotExist:
             # None found... make a new one!
             at = self.create_access_token(request, user, scope, client)


### PR DESCRIPTION
Fix `get_access_token()` failing with multiple orders returned on single tracker mode, after token refresh.

Issue https://github.com/caffeinehit/django-oauth2-provider/issues/70
