### PR TITLE
Made redirect URLs keep query params

### DIFF
--- a/provider/views.py
+++ b/provider/views.py
@@ -322,7 +322,7 @@ class Redirect(OAuthView, Mixin):
 
         parsed = urlparse.urlparse(redirect_uri)
 
-        query = QueryDict('', mutable=True)
+        query = QueryDict(parsed[4], mutable=True)
 
         if 'state' in data:
             query['state'] = data['state']


### PR DESCRIPTION
This commit makes the redirect back to the client app maintain the query arguments that were passed with the original authorise. This is required for a number of apps including the Meteor accounts packages (http://github.com/uowits/meteor-accounts-uow).

The OAuth2 RFC says that OAuth2 providers MUST implement this functionality.
http://tools.ietf.org/html/rfc6749#section-3.1.2

> The redirection endpoint URI MUST be an absolute URI as defined by
> [RFC3986] Section 4.3.  The endpoint URI MAY include an
> "application/x-www-form-urlencoded" formatted (per Appendix B) query
> component ([RFC3986] Section 3.4), which MUST be retained when adding
> additional query parameters.  The endpoint URI MUST NOT include a
> fragment component.
