### PR TITLE
Replace uses of the "mimetype" arg of HttpResponse with "content_type".

### DIFF
--- a/provider/views.py
+++ b/provider/views.py
@@ -292,14 +292,13 @@ class Redirect(OAuthView, Mixin):
     an error.
     """
 
-    def error_response(self, error, mimetype='application/json', status=400,
-            **kwargs):
+    def error_response(self, error, status=400, **kwargs):
         """
         Return an error response to the client with default status code of
         *400* stating the error as outlined in :rfc:`5.2`.
         """
-        return HttpResponse(json.dumps(error), mimetype=mimetype,
-                status=status, **kwargs)
+        kwargs.setdefault('content_type', 'application/json')
+        return HttpResponse(json.dumps(error), status=status, **kwargs)
 
     def get(self, request):
         data = self.get_data(request)
@@ -457,14 +456,13 @@ class AccessToken(OAuthView, Mixin):
         """
         raise NotImplementedError
 
-    def error_response(self, error, mimetype='application/json', status=400,
-            **kwargs):
+    def error_response(self, error, status=400, **kwargs):
         """
         Return an error response to the client with default status code of
         *400* stating the error as outlined in :rfc:`5.2`.
         """
-        return HttpResponse(json.dumps(error), mimetype=mimetype,
-                status=status, **kwargs)
+        kwargs.setdefault('content_type', 'application/json')
+        return HttpResponse(json.dumps(error), status=status, **kwargs)
 
     def access_token_response(self, access_token):
         """
@@ -488,7 +486,7 @@ class AccessToken(OAuthView, Mixin):
             pass
 
         return HttpResponse(
-            json.dumps(response_data), mimetype='application/json'
+            json.dumps(response_data), content_type='application/json'
         )
 
     def authorization_code(self, request, data, client):


### PR DESCRIPTION
mimetype has been deprecated for a long time and has been removed from
django in the development version. This commit uses content_type for
the default value but allows specifying either, regardless of the
version of Django. Specifying "mimetype" will work for users of
django-oauth2-provider if their version of django supports it (the
deprecated argument has precedence), and will break if it doesn't.
