### PR TITLE
Refactor AccessToken view to allow adding extra parameters.

### DIFF
--- a/provider/views.py
+++ b/provider/views.py
@@ -466,10 +466,11 @@ class AccessToken(OAuthView, Mixin):
         return HttpResponse(json.dumps(error), mimetype=mimetype,
                 status=status, **kwargs)
 
-    def access_token_response(self, access_token):
+    def access_token_response_data(self, access_token):
         """
-        Returns a successful response after creating the access token
-        as defined in :rfc:`5.1`.
+        Returns access token data as defined in :rfc:`5.1`.
+
+        Derived classes can override to add extra parameters.
         """
 
         response_data = {
@@ -486,6 +487,15 @@ class AccessToken(OAuthView, Mixin):
             response_data['refresh_token'] = rt.token
         except ObjectDoesNotExist:
             pass
+
+        return response_data
+
+    def access_token_response(self, access_token):
+        """
+        Returns a successful response after creating the access token
+        as defined in :rfc:`5.1`.
+        """
+        response_data = self.access_token_response_data(access_token)
 
         return HttpResponse(
             json.dumps(response_data), mimetype='application/json'


### PR DESCRIPTION
OAuth2 allows for extra parameters in the access token response, which
is frequently done by OAuth2 providers to fit their needs.

It is also required for protocols such as OpenID Connect, build
on top of OAuth2, which adds a id_token parameter.

Subclesses of AccessToken, should be able to easily add more parameters,
without repeating code of the parent class.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caffeinehit/django-oauth2-provider/89)

<!-- Reviewable:end -->
