### PR TITLE
Fix error when clients have no associated user

### DIFF
--- a/provider/tests/test_utils.py
+++ b/provider/tests/test_utils.py
@@ -33,3 +33,18 @@ class UtilsTestCase(TestCase):
             #   datetime.time(10, 6, 28, 705000)
             self.assertEqual(int(t1.microsecond/1000),
                              int(t2.microsecond/1000))
+
+    def test_none_child_(self):
+        class ChildModel(models.Model):
+            pass
+
+        class ParentModel(models.Model):
+            child = models.ForeignKey(ChildModel, null=True)
+
+        reference = ParentModel()
+
+        data = utils.serialize_instance(reference)
+        self.assertEqual(data['child_id'], None)
+
+        instance = utils.deserialize_instance(ParentModel, data)
+        self.assertEqual(instance.child, None)

--- a/provider/utils.py
+++ b/provider/utils.py
@@ -77,7 +77,7 @@ def serialize_instance(instance):
     """
     ret = dict([(k, v)
                 for k, v in instance.__dict__.items()
-                if not k.startswith('_')])
+                if not k.startswith('_')]) if instance else None
     return json.loads(json.dumps(ret, cls=DjangoJSONEncoder))
 
 


### PR DESCRIPTION
The user field of the Client model is mark as nullable. However, during
serialization it is expected to be a dictionary, throwing an
error.

Fixed by checking if the user is None and serializing as null.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/caffeinehit/django-oauth2-provider/92)

<!-- Reviewable:end -->
