### PR TITLE
Fix tests for Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - DJANGO="django>=1.4,<1.5"
   - DJANGO="django>=1.5,<1.6"
   - DJANGO="django>=1.6,<1.7"
+  - DJANGO="django>=1.7,<1.8"
 python:
   - "2.6"
   - "2.7"

--- a/provider/oauth2/fixtures/test_oauth2_17.json
+++ b/provider/oauth2/fixtures/test_oauth2_17.json
@@ -1,0 +1,62 @@
+[
+    {
+        "fields": {
+            "redirect_uri": "http://example.com/application/1/", 
+            "client_id": "90a4a24ffefe7ebbae2c", 
+            "client_secret": "35c25066023f32c4f098d1e40de94f07f98c1acf", 
+            "client_type": 0, 
+            "url": "http://example.com/", 
+            "user": 1
+        }, 
+        "model": "provider.client", 
+        "pk": 1
+    }, 
+    {
+        "fields": {
+            "redirect_uri": "http://example.com/application/2/", 
+            "client_id": "71fbc29950ac1b386a12", 
+            "client_secret": "1944b695ca0cbf4f419a7d5c7e4fed13a660bc04", 
+            "client_type": 0, 
+            "url": "http://example.com/", 
+            "user": 2
+        }, 
+        "model": "provider.client", 
+        "pk": 2
+    }, 
+    {
+        "fields": {
+            "date_joined": "2012-01-23 05:44:17", 
+            "email": "test-1@example.com", 
+            "first_name": "", 
+            "groups": [], 
+            "is_active": true, 
+            "is_staff": true, 
+            "is_superuser": true, 
+            "last_login": "2012-01-23 05:52:32", 
+            "last_name": "", 
+            "password": "sha1$da29e$498b9faab2d002183bc1d874689634b0e15ad6d7", 
+            "user_permissions": [], 
+            "username": "test-user-1"
+        }, 
+        "model": "auth.user", 
+        "pk": 1
+    }, 
+    {
+        "fields": {
+            "date_joined": "2012-01-23 05:53:31", 
+            "email": "", 
+            "first_name": "", 
+            "groups": [], 
+            "is_active": true, 
+            "is_staff": false, 
+            "is_superuser": false, 
+            "last_login": "2012-01-23 05:53:31", 
+            "last_name": "", 
+            "password": "sha1$0cf1b$d66589690edd96b410170fcae5cc2bdfb68821e7", 
+            "user_permissions": [], 
+            "username": "test-user-2"
+        }, 
+        "model": "auth.user", 
+        "pk": 2
+    }
+]

--- a/provider/oauth2/tests.py
+++ b/provider/oauth2/tests.py
@@ -1,6 +1,7 @@
 import json
 import urlparse
 import datetime
+from django import VERSION as DJANGO_VERSION
 from django.http import QueryDict
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -15,6 +16,11 @@ from .forms import ClientForm
 from .models import Client, Grant, AccessToken, RefreshToken
 from .backends import BasicClientBackend, RequestParamsClientBackend
 from .backends import AccessTokenBackend
+
+FIXTURES = ['test_oauth2']
+
+if DJANGO_VERSION[0] == 1 and DJANGO_VERSION[1] >= 7:
+    FIXTURES = ['test_oauth2_17']
 
 
 @skipIfCustomUser
@@ -59,7 +65,7 @@ class BaseOAuth2TestCase(TestCase):
 
 
 class AuthorizationTest(BaseOAuth2TestCase):
-    fixtures = ['test_oauth2']
+    fixtures = FIXTURES
 
     def setUp(self):
         self._old_login = settings.LOGIN_URL
@@ -202,7 +208,7 @@ class AuthorizationTest(BaseOAuth2TestCase):
 
 
 class AccessTokenTest(BaseOAuth2TestCase):
-    fixtures = ['test_oauth2.json']
+    fixtures = FIXTURES
 
     def test_access_token_get_expire_delta_value(self):
         user = self.get_user()
@@ -450,7 +456,7 @@ class AccessTokenTest(BaseOAuth2TestCase):
 
 
 class AuthBackendTest(BaseOAuth2TestCase):
-    fixtures = ['test_oauth2']
+    fixtures = FIXTURES
 
     def test_basic_client_backend(self):
         request = type('Request', (object,), {'META': {}})()
@@ -482,7 +488,7 @@ class AuthBackendTest(BaseOAuth2TestCase):
 
 
 class EnforceSecureTest(BaseOAuth2TestCase):
-    fixtures = ['test_oauth2']
+    fixtures = FIXTURES
 
     def setUp(self):
         constants.ENFORCE_SECURE = True
@@ -556,7 +562,7 @@ class ScopeTest(TestCase):
 
 
 class DeleteExpiredTest(BaseOAuth2TestCase):
-    fixtures = ['test_oauth2']
+    fixtures = FIXTURES
 
     def setUp(self):
         self._delete_expired = constants.DELETE_EXPIRED

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ DJ_VERSION=$(django-admin.py --version)
 # exit if fail
 [[ "$?" -ne "0" ]] && exit;
 
-IS_16=$(echo $DJ_VERSION | grep "1.6")
+IS_16_OR_17=$(echo $DJ_VERSION | grep -e "1.[67]")
 
 # if django version is not 1.6 (non-0 exit) we have to pass different
 # app names to test runner

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 # Django settings for example project.
 import os
 
+from django import VERSION as DJANGO_VERSION
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -60,3 +62,15 @@ INSTALLED_APPS = (
     'provider.oauth2',
 )
 
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+# Use DiscoverRunner on Django 1.7 and above
+if DJANGO_VERSION[0] == 1 and DJANGO_VERSION[1] >= 7:
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'


### PR DESCRIPTION
This PR fixes tests for 1.7.
- The defaults for `MIDDLEWARE_CLASSES` changed so we need to specify sane defaults.
- There's something going in with model names in fixtures in 1.7 for sub-apps; `oauth2.client` becomes `provider.client` in the fixture.
- We need to specify the new test runner in 1.7 to avoid warnings.
- I added the 1.7 tests to `.travis.yml`.
