### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ django-oauth2-provider
 *django-oauth2-provider* is a Django application that provides
 customizable OAuth2\-authentication for your Django projects.
 
-`Documentation <http://readthedocs.org/docs/django-oauth2-provider/en/latest/>`_
+`Documentation <https://django-oauth2-provider.readthedocs.io/en/latest/>`_
 
 `Help <https://groups.google.com/d/forum/django-oauth2-provider>`_
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.